### PR TITLE
Clean up outdated references in docs and release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 **Django-SHOP** aims to be a the easy, fun and fast e-commerce counterpart to
 [django-CMS](https://www.django-cms.org/).
 
-[![Build Status](https://travis-ci.org/awesto/django-shop.svg?branch=master)](https://travis-ci.org/awesto/django-shop?branch=master)
-[![PyPI version](https://img.shields.io/pypi/v/django-shop.svg)](https://pypi.python.org/pypi/django-shop)
-[![Python versions](https://img.shields.io/pypi/pyversions/django-shop.svg)](https://pypi.python.org/pypi/django-shop)
+[![PyPI version](https://img.shields.io/pypi/v/django-shop.svg)](https://pypi.org/project/django-shop/)
+[![Python versions](https://img.shields.io/pypi/pyversions/django-shop.svg)](https://pypi.org/project/django-shop/)
 [![Join the chat at https://gitter.im/awesto/django-shop](https://badges.gitter.im/awesto/django-shop.svg)](https://gitter.im/awesto/django-shop?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Software license](https://img.shields.io/pypi/l/django-shop.svg)](https://pypi.python.org/pypi/django-shop)
+[![Software license](https://img.shields.io/pypi/l/django-shop.svg)](https://pypi.org/project/django-shop/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/djangoSHOP.svg?style=social&label=djangoSHOP)](https://twitter.com/djangoSHOP)
 
 Here you can find the [full documentation for django-SHOP](https://django-shop.readthedocs.io/en/latest/).

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -25,7 +25,7 @@ Setting up the environment
 --------------------------
 
 We highly suggest you run the tests suite in a clean environment, using a tool such as
-`virtualenv <http://pypi.python.org/pypi/virtualenv>`_.
+`virtualenv <https://pypi.org/project/virtualenv/>`_.
 
 1. Clone the repository and cd into it:
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -378,7 +378,7 @@ configuration. Please remember that e-mail is sent asynchronously via django-pos
 	EMAIL_REPLY_TO = 'info@example.com'
 	EMAIL_BACKEND = 'post_office.EmailBackend'
 
-.. _django-post_office: https://pypi.python.org/pypi/django-post_office
+.. _django-post_office: https://pypi.org/project/django-post-office/
 
 
 Session Handling

--- a/shop/__init__.py
+++ b/shop/__init__.py
@@ -1,5 +1,5 @@
 """
-See PEP 386 (http://www.python.org/dev/peps/pep-0386/)
+See PEP 440 (https://www.python.org/dev/peps/pep-0440/)
 
 Release logic:
  1. Increase version number in __version__ (below)
@@ -8,7 +8,7 @@ Release logic:
  4. git add shop/__init__.py docs/changelog.rst setup.py
  5. git commit -m 'Bump to {new version}'
  6. git push
- 7. assure that all tests pass on https://travis-ci.org/awesto/django-shop
+ 7. assure that all tests pass in the CI pipeline
  8. git tag {new version}
  9. git push --tags
 10. python setup.py sdist


### PR DESCRIPTION
## Summary
- drop Travis CI badge
- point PyPI links to pypi.org
- update release instructions to use generic CI terminology
- refresh documentation links

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b303b0fa808320a1412fc0cd6fb992